### PR TITLE
Removing unnecessary methods

### DIFF
--- a/src/WRSoftware.Utils.EntityFramework/Interfaces/CQRS/ICommandRepository.cs
+++ b/src/WRSoftware.Utils.EntityFramework/Interfaces/CQRS/ICommandRepository.cs
@@ -46,19 +46,6 @@ namespace WRSoftware.Utils.EntityFrameworkCore.Interfaces.CQRS
         Task UpdateAsync(TEntity entity);
 
         /// <summary>
-        /// Softs the delete.
-        /// </summary>
-        /// <param name="filter">The filter.</param>
-        void SoftDelete(Expression<Func<TEntity, bool>> filter);
-
-        /// <summary>
-        /// Softs the delete asynchronous.
-        /// </summary>
-        /// <param name="filter">The filter.</param>
-        /// <returns></returns>
-        Task SoftDeleteAsync(Expression<Func<TEntity, bool>> filter);
-
-        /// <summary>
         /// Hards the delete.
         /// </summary>
         /// <param name="id">The identifier.</param>

--- a/src/WRSoftware.Utils.EntityFramework/Repositories/CQRS/GenericCommandRepository.cs
+++ b/src/WRSoftware.Utils.EntityFramework/Repositories/CQRS/GenericCommandRepository.cs
@@ -169,19 +169,6 @@ namespace WRSoftware.Utils.EntityFrameworkCore.Repositories.CQRS
             return (await this._dbSet.AddAsync(entity, new CancellationToken())).Entity;
         }
 
-        /// <summary>
-        /// Softs the delete.
-        /// </summary>
-        /// <param name="filter">The filter.</param>
-        public abstract void SoftDelete(Expression<Func<TEntity, bool>> filter);
-
-        /// <summary>
-        /// Softs the delete asynchronous.
-        /// </summary>
-        /// <param name="filter">The filter.</param>
-        /// <returns></returns>
-        public abstract Task SoftDeleteAsync(Expression<Func<TEntity, bool>> filter);
-
         public virtual void Update(TEntity entity)
         {
             this._dbSet.Attach(entity);

--- a/src/WRSoftware.Utils.EntityFramework/Repositories/GenericRepository.cs
+++ b/src/WRSoftware.Utils.EntityFramework/Repositories/GenericRepository.cs
@@ -596,19 +596,6 @@ namespace WRSoftware.Utils.EntityFramework.Repositories
             return (await this._dbSet.AddAsync(entity, new CancellationToken())).Entity;
         }
 
-        /// <summary>
-        /// Softs the delete.
-        /// </summary>
-        /// <param name="filter">The filter.</param>
-        public abstract void SoftDelete(Expression<Func<TEntity, bool>> filter);
-
-        /// <summary>
-        /// Softs the delete asynchronous.
-        /// </summary>
-        /// <param name="filter">The filter.</param>
-        /// <returns></returns>
-        public abstract Task SoftDeleteAsync(Expression<Func<TEntity, bool>> filter);
-
         public virtual void Update(TEntity entity)
         {
             this._dbSet.Attach(entity);


### PR DESCRIPTION
The `ICommandRepository` has these two methods that are not implemented:

`SoftDelete`
`SoftDeleteAsync`

As these methods are just a logic delete and that will depend from system to system, this library should not obligate it to be implemented and will help to avoid unnecessary code.